### PR TITLE
Allow including SimpleAPI from C++11 source

### DIFF
--- a/jetpack/src/SimpleAPI.h
+++ b/jetpack/src/SimpleAPI.h
@@ -8,7 +8,7 @@
 #include <cstdlib>
 #include <cstring>
 
-namespace jetpack::simple_api {
+namespace jetpack { namespace simple_api {
 
     struct Flags {
     public:
@@ -90,4 +90,4 @@ namespace jetpack::simple_api {
 
     int HandleCommandLine(int argc, char** argv);
 
-}
+}}


### PR DESCRIPTION
Hi @vincentdchan !

I found a small change that allows using SimpleAPI.h from C++11 code, which avoids having to set respective flags for the embedding project (and will probably also help with compile times in those embedding projects).

Best,
Jonathan