### PR TITLE
Allow overriding basePath instead of searching for package.json

### DIFF
--- a/jetpack/src/ModuleResolver.cpp
+++ b/jetpack/src/ModuleResolver.cpp
@@ -94,7 +94,7 @@ namespace jetpack {
         std::cerr << "Error: " << error_content << std::endl;
     }
 
-    void ModuleResolver::BeginFromEntry(const parser::ParserContext::Config& config, const std::string& targetPath) {
+    void ModuleResolver::BeginFromEntry(const parser::ParserContext::Config& config, const std::string& targetPath, const std::string& basePathOverride) {
         std::string absolutePath;
         if (targetPath.empty()) {
             return;
@@ -106,7 +106,7 @@ namespace jetpack {
             absolutePath = p.ToString();
         }
 
-        auto basePath = FindPathOfPackageJson(absolutePath);
+        auto basePath = basePathOverride.empty() ? FindPathOfPackageJson(absolutePath) : basePathOverride;
         if (unlikely(!basePath.has_value())) {
             throw ModuleResolveException(absolutePath, "can not find package.json");
         }

--- a/jetpack/src/ModuleResolver.h
+++ b/jetpack/src/ModuleResolver.h
@@ -59,7 +59,8 @@ namespace jetpack {
         }
 
         void BeginFromEntry(const parser::ParserContext::Config& config,
-                            const std::string& originPath);
+                            const std::string& originPath,
+                            const std::string& basePathOverride="");
 
         void BeginFromEntryString(const parser::ParserContext::Config& config,
                                   UString str);

--- a/jetpack/src/SimpleAPI.cpp
+++ b/jetpack/src/SimpleAPI.cpp
@@ -27,7 +27,7 @@
 
 namespace jetpack::simple_api {
 
-    int AnalyzeModule(const std::string& path, Flags flags) {
+    int AnalyzeModule(const std::string& path, Flags flags, const std::string& basePath) {
         parser::ParserContext::Config parser_config = parser::ParserContext::Config::Default();
         if (flags.isJsx()) {
             parser_config.jsx = true;
@@ -39,7 +39,7 @@ namespace jetpack::simple_api {
 
         try {
             resolver->SetTraceFile(flags.isTraceFile());
-            resolver->BeginFromEntry(parser_config, path);
+            resolver->BeginFromEntry(parser_config, path, basePath);
             resolver->PrintStatistic();
             return 0;
         } catch (ModuleResolveException& err) {
@@ -48,7 +48,7 @@ namespace jetpack::simple_api {
         }
     }
 
-    int BundleModule(const std::string& path, const std::string& out_path, Flags flags) {
+    int BundleModule(const std::string& path, const std::string& out_path, Flags flags, const std::string& basePath) {
 
         auto start = time::GetCurrentMs();
 
@@ -72,7 +72,7 @@ namespace jetpack::simple_api {
             codegen_config.sourcemap = flags.isSourcemap();
 
             resolver->SetTraceFile(true);
-            resolver->BeginFromEntry(parser_config, path);
+            resolver->BeginFromEntry(parser_config, path, basePath);
             resolver->CodeGenAllModules(codegen_config, out_path);
 
             std::cout << "Finished." << std::endl;

--- a/jetpack/src/SimpleAPI.h
+++ b/jetpack/src/SimpleAPI.h
@@ -83,10 +83,14 @@ namespace jetpack::simple_api {
         bool profile_malloc : 1;
     };
 
-    int AnalyzeModule(const std::string& path, Flags flags);
+    int AnalyzeModule(const std::string& path,
+                      Flags flags,
+                      const std::string& base_path="");
 
     int BundleModule(const std::string& path,
-                     const std::string& out_path, Flags flags);
+                     const std::string& out_path,
+                     Flags flags,
+                     const std::string& base_path="");
 
     int HandleCommandLine(int argc, char** argv);
 


### PR DESCRIPTION
Hey @vincentdchan !

Sorry for the many pullrequests, I'm splitting them up such that you can choose the changes you want to use more easily.

Since some projects may not be using package.json, and the file is not used for anything but finding the base path, I added a `basePathOverride` parameter in `AnalyzeModule` and `BundleModule` such that package.json is now optional. This should be fully backwards compatible with the previous API.

Best,
Jonathan